### PR TITLE
Fixed bug in calculate_base_resistance

### DIFF
--- a/debeer/calculation.py
+++ b/debeer/calculation.py
@@ -307,7 +307,7 @@ class DeBeerCalculation(object):
             self.diameter_2 = self.diameter_pile
         else:
             self.diameter_1 = np.round(self.diameter_pile - (self.diameter_pile % 0.2), 1)
-            self.diameter_2 = np.round(self.diameter_pile + (self.diameter_pile % 0.2), 1)
+            self.diameter_2 = self.diameter_1 + 0.2
         self.calc_1 = self.calculate_base_resistance_standard_diameter(
             pile_diameter=self.diameter_1, vanimpecorrection=vanimpecorrection, hcrit=hcrit
         )


### PR DESCRIPTION
If the pile dimeter is not a multiple of 0.2m, the unit base resistance is calculated for the closeby diameters which are a multiple of 0.2. 

Before the bug fix, a diameter of 0.21 would result in a calculation for round(0.21 - 0.01 ( = 0.21 % 0.2 ), 1) = 0.20 and round(0.21 + 0.01 ( = 0.21 % 0.2 ) , 1) = 0.20. This is a mistake, it should be 0.20 (lower bound) and 0.25 (upper bound).